### PR TITLE
Corrects typo of `fs` to `fsUtil`

### DIFF
--- a/app/out/docpad.js
+++ b/app/out/docpad.js
@@ -217,7 +217,7 @@ docpadConfig = {
         repoValue = repos[repoKey];
         tasks.push(repoValue, function(complete) {
           var _this = this;
-          if (opts.reset === true || fs.existsSync(this.path) === false) {
+          if (opts.reset === true || fsUtil.existsSync(this.path) === false) {
             docpad.log('info', "Updating " + this.name + "...");
             return balUtil.initOrPullGitRepo(balUtil.extend({
               remote: 'origin',

--- a/app/src/docpad.coffee
+++ b/app/src/docpad.coffee
@@ -273,7 +273,7 @@ docpadConfig =
 			# Cycle through the repos assigning each repo value to @ so it works asynchronously
 			for own repoKey,repoValue of repos
 				tasks.push repoValue, (complete) ->
-					if opts.reset is true or fs.existsSync(@path) is false
+					if opts.reset is true or fsUtil.existsSync(@path) is false
 						# Log
 						docpad.log('info', "Updating #{@name}...")
 


### PR DESCRIPTION
Just a quick fix.
Without it DocPad prevents refreshed pages from loading.
